### PR TITLE
Zheng07Sats generalization

### DIFF
--- a/docs/quickstart_and_tutorials/tutorials/model_building/composing_models/hod_modeling/zheng07_using_cenocc_model_tutorial.rst
+++ b/docs/quickstart_and_tutorials/tutorials/model_building/composing_models/hod_modeling/zheng07_using_cenocc_model_tutorial.rst
@@ -1,0 +1,78 @@
+:orphan:
+
+.. _zheng07_using_cenocc_model_tutorial:
+
+************************************************
+Advanced usage of the ``zheng07`` model
+************************************************
+
+.. currentmodule:: halotools.empirical_models
+
+As described in the :ref:`zheng07_composite_model` tutorial, the ``zheng07`` model
+gives you control over whether the :math:`\langle N_{\rm sat} \rangle` function
+is multiplied by a :math:`\langle N_{\rm cen} \rangle` prefactor.
+If you are using the `PrebuiltHodModelFactory` with the ``zheng07`` model name,
+then your only choice for how :math:`\langle N_{\rm cen} \rangle` prefactor is computed is
+the model used in `Zheng et al 2007 <http://arxiv.org/abs/astro-ph/0703457>`_.
+
+However, the ``cenocc_model`` keyword of `Zheng07Sats` allows you
+to calculate the :math:`\langle N_{\rm cen} \rangle` prefactor
+using *any* `OccupationComponent`, including one of your own design.
+To build a composite HOD model using the ``cenocc_model`` keyword,
+you must call the `HodModelFactory` directly, rather than the `PrebuiltHodModelFactory`.
+In the code below, we will demonstrate an explicit example of how to do so.
+Note the similarity of the code below to the `zheng07_model_dictionary` source code.
+
+First we create a new (rather trivial) `OccupationComponent` sub-class that we will
+use for our centrals.
+
+.. code::
+
+	from halotools.empirical_models import OccupationComponent
+	class MyCenModel(OccupationComponent):
+
+	    def __init__(self, threshold):
+	        OccupationComponent.__init__(self, gal_type='centrals',
+	        		threshold=threshold, upper_occupation_bound=1.)
+
+	        self.param_dict['new_cen_param'] = 0.5
+
+	    def mean_occupation(self, **kwargs):
+	    	halo_table = kwargs['table']
+	    	result = np.zeros(len(halo_table)) + self.param_dict['new_cen_param']
+	        return result
+
+Now we will build an instance of ``MyCenModel``,
+and use the ``cenocc_model`` keyword of `Zheng07Sats` to create a custom version
+of this satellite model.
+
+.. code::
+
+	centrals_occupation = MyCenModel(threshold=-20)
+	satellites_occupation = Zheng07Sats(threshold=-20, modulate_with_cenocc=True, cenocc_model=centrals_occupation)
+
+Finally, we make the same choices for the profile modeling as made in the normal
+pre-built ``zheng07`` composite model, and then pass the resulting collection
+of components to the `HodModelFactory`.
+
+.. code::
+
+	from halotools.empirical_models import TrivialPhaseSpace, NFWPhaseSpace
+	centrals_profile = TrivialPhaseSpace()
+	satellites_profile = NFWPhaseSpace()
+
+	from halotools.empirical_models import HodModelFactory
+	model_dict = {'centrals_occupation': centrals_occupation, 'centrals_profile': centrals_profile, 'satellites_occupation': satellites_occupation, 'satellites_profile': satellites_profile}
+	composite_model = HodModelFactory(**model_dict)
+
+.. note::
+
+	Halotools provides no checks on the self-consistency between your choice for
+	``centrals_occupation`` and the model instance bound to the ``cenocc_model``
+	keyword. If you use the ``cenocc_model`` keyword when building a composite HOD model,
+	then it is your responsibility to self-consistently use the same model for your
+	centrals as for the ``cenocc_model`` argument. If you don't, then changes to the
+	values in the ``param_dict`` of the composite model that pertain to
+	``centrals_occupation`` will not propagate through to the behavior of ``satellites_occupation``.
+
+

--- a/docs/quickstart_and_tutorials/tutorials/model_building/preloaded_models/zheng07_composite_model.rst
+++ b/docs/quickstart_and_tutorials/tutorials/model_building/preloaded_models/zheng07_composite_model.rst
@@ -40,10 +40,13 @@ You can build an instance of this model using the
 Customizing the Zheng et al. (2007) Model
 ===============================================
 
-There are two keyword arguments you can use to customize
-the instance returned by the factory:
+There are three keyword arguments you can use to customize
+the instance returned by the factory, ``threshold``, ``redshift`` and
+``modulate_with_cenocc``. In this section, we cover each of these keywords in turn.
 
-First, the ``threshold`` keyword argument pertains to the r-band absolute magnitude
+Role of the ``threshold`` keyword
+-----------------------------------
+The ``threshold`` keyword argument pertains to the r-band absolute magnitude
 of the luminosity of the galaxy sample:
 
 >>> model = PrebuiltHodModelFactory('zheng07', threshold = -20)
@@ -58,24 +61,6 @@ of the ``default_luminosity_threshold`` variable set in the
 `~halotools.empirical_models.model_defaults` module, and you can proceed to
 alter the ``param_dict`` however you like (see below).
 
-.. note::
-
-	If you are trying to strictly reproduce the results in Zheng et al. (2007),
-	you should set the ``modulate_with_cenocc`` keyword to True.
-
-	>>> model = PrebuiltHodModelFactory('zheng07', threshold=-20, modulate_with_cenocc=True)
-
-	When ``modulate_with_cenocc`` is True, then the value of
-	:math:`\langle N_{\rm sat}\rangle(M_{\rm vir})` is multiplied by
-	:math:`\langle N_{\rm cen}\rangle(M_{\rm vir})`.
-
-	The default value is False, though in Zheng+07, their model for
-	:math:`\langle N_{\rm sat}\rangle(M_{\rm vir})` does include the prefactor.
-	For typical regions of parameter space, the choice of whether or not to include
-	this prefactor has a very small impact on the satellite occupation statistics.
-	See the `~halotools.empirical_models.Zheng07Cens` docstring for further
-	details on the ``modulate_with_cenocc`` keyword.
-
 As described in :ref:`altering_param_dict`, you can always change the model parameters
 after instantiation by changing the values in the ``param_dict`` dictionary. For example,
 
@@ -85,13 +70,53 @@ The above line of code changes the minimum mass for
 a halo to host a central galaxy to :math:`10^{12.5}M_{\odot}`.
 See :ref:`zheng07_parameters` for a description of all parameters of this model.
 
-Second, the ``redshift`` keyword argument must be set to the redshift of the
+Role of the ``redshift`` keyword
+-----------------------------------
+The ``redshift`` keyword argument must be set to the redshift of the
 halo catalog you might populate with this model.
 
 >>> model = PrebuiltHodModelFactory('zheng07', threshold = -20, redshift = 2)
 
 For the ``zheng07`` model, the ``redshift`` attribute has no impact whatsoever on
-the behavior of the model; the purpose of this keyword for factory standardization purposes only.
+the behavior of the model; the purpose of this keyword for factory standardization purposes only,
+and also to remind users that this model has only been calibrated against *z=0* observational data.
+
+
+Role of the ``modulate_with_cenocc`` keyword
+----------------------------------------------
+
+.. note::
+
+	As described in the docstring, if you are trying to strictly reproduce
+	the results in `Zheng et al 2007 <http://arxiv.org/abs/astro-ph/0703457>`_.
+	you should set the ``modulate_with_cenocc`` keyword to True.
+	Note that the default value is False, which for typical regions of parameter
+	space gives very similar behavior to the published results.
+
+The ``modulate_with_cenocc`` keyword argument controls how the
+`Zheng07Sats.mean_occupation` function is calculated.
+The default value is False, in which case the `Zheng07Sats.mean_occupation`
+function is calculated according to the following equation:
+
+.. math::
+
+	\langle N_{\mathrm{sat}} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha}
+
+When ``modulate_with_cenocc`` is True, then the value of
+:math:`\langle N_{\rm sat}\rangle(M_{\rm vir})` as calculated above
+will be multiplied by an overall factor of
+:math:`\langle N_{\rm cen}\rangle(M_{\rm vir})`,
+where the factor of :math:`\langle N_{\rm cen}\rangle` is defined
+according to `Zheng07Cens.mean_occupation`:
+
+.. math::
+
+        \langle N_{\mathrm{cen}} \rangle(M_{\rm vir}) = \frac{1}{2}\left( 1 + \mathrm{erf}\left( \frac{\log_{10}M - \log_{10}M_{min}}{\sigma_{\log_{10}M}} \right) \right)
+
+If you wish to modulate your satellite occupation statistics using
+alternative models for :math:`\langle N_{\rm cen}\rangle(M_{\rm vir})`,
+see :ref:`zheng07_using_cenocc_model_tutorial`.
+
 
 Populating Mocks and Generating Zheng et al. (2007) Model Predictions
 =======================================================================

--- a/halotools/empirical_models/composite_models/hod_models/tests/test_zheng07.py
+++ b/halotools/empirical_models/composite_models/hod_models/tests/test_zheng07.py
@@ -1,0 +1,61 @@
+"""
+"""
+from astropy.tests.helper import pytest
+import numpy as np
+
+from ....occupation_models import OccupationComponent, Zheng07Cens, Zheng07Sats
+from ....phase_space_models import TrivialPhaseSpace, NFWPhaseSpace
+from ....factories import PrebuiltHodModelFactory, HodModelFactory
+
+from .....custom_exceptions import HalotoolsError
+from .....sim_manager import FakeSim
+
+__all__ = ('test_zheng07_composite1', 'test_zheng07_composite2')
+
+
+def test_zheng07_composite1():
+    """ Ensure that the ``zheng07`` pre-built model does not accept non-Zheng07Cens.
+    """
+    model1 = PrebuiltHodModelFactory('zheng07')
+    model2 = PrebuiltHodModelFactory('zheng07', modulate_with_cenocc=True)
+
+    with pytest.raises(HalotoolsError) as err:
+        __ = PrebuiltHodModelFactory('zheng07', modulate_with_cenocc=True, cenocc_model=0)
+    substr = "Do not pass in the ``cenocc_model`` keyword to ``zheng07_model_dictionary``"
+    assert substr in err.value.args[0]
+
+
+def test_zheng07_composite2():
+    """ This test ensures that the source code provided in the
+    ``Advanced usage of the ``zheng07`` model`` tutorial behaves as expected.
+    """
+
+    class MyCenModel(OccupationComponent):
+
+        def __init__(self, threshold):
+            OccupationComponent.__init__(self, gal_type='centrals',
+                    threshold=threshold, upper_occupation_bound=1.)
+
+            self.param_dict['new_cen_param'] = 0.5
+
+        def mean_occupation(self, **kwargs):
+            halo_table = kwargs['table']
+            result = np.zeros(len(halo_table)) + self.param_dict['new_cen_param']
+            return result
+
+    centrals_occupation = MyCenModel(threshold=-20)
+    satellites_occupation = Zheng07Sats(threshold=-20,
+        modulate_with_cenocc=True, cenocc_model=centrals_occupation)
+
+    centrals_profile = TrivialPhaseSpace()
+    satellites_profile = NFWPhaseSpace()
+
+    model_dict = ({'centrals_occupation': centrals_occupation,
+        'centrals_profile': centrals_profile,
+        'satellites_occupation': satellites_occupation,
+        'satellites_profile': satellites_profile})
+
+    composite_model = HodModelFactory(**model_dict)
+
+    fake_sim = FakeSim()
+    composite_model.populate_mock(fake_sim)

--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -14,6 +14,7 @@ from .hod_mock_factory import HodMockFactory
 
 from .. import model_helpers
 
+from ..occupation_models import OccupationComponent
 from ...sim_manager import sim_defaults
 from ...custom_exceptions import HalotoolsError
 
@@ -221,6 +222,8 @@ class HodModelFactory(ModelFactory):
             #  at the syntax-level that the model_dictionary and _input_model_dictionary
             #  are fully independent, not pointers to the same locations in memory
             self.model_dictionary[key] = copy(self._input_model_dictionary[key])
+
+        self._test_censat_occupation_consistency(self.model_dictionary)
 
         # Build up and bind several lists from the component models
         self.set_gal_types()
@@ -997,6 +1000,50 @@ class HodModelFactory(ModelFactory):
         for method in self._mock_generation_calling_sequence:
             if not hasattr(self, method):
                 raise HalotoolsError(missing_method_msg2)
+
+    def _test_censat_occupation_consistency(self, model_dictionary):
+        """ This private method searches each OccupationComponent instance for a
+        ``central_occupation_model`` attribute. If detected, a check is made on the
+        self-consistency between the class of the object bound to that attribute,
+        and the class of the occupation model actually bound to the centrals population.
+        """
+        occu_model_list = list(obj for obj in model_dictionary.values()
+            if isinstance(obj, OccupationComponent))
+
+        actual_cenocc_model_exists = False
+        for i, occu_model in enumerate(occu_model_list):
+            try:
+                gal_type = occu_model.gal_type
+                if gal_type == 'centrals':
+                    actual_cenocc_model = occu_model
+                    actual_cenocc_model_exists = True
+            except AttributeError:
+                pass
+
+        if not actual_cenocc_model_exists:
+            # There is no central occupation model to be inconsistent with
+            return
+        else:
+            for component_model in occu_model_list:
+                try:
+                    subordinate_cenocc_model = getattr(component_model, 'central_occupation_model')
+                    assert isinstance(subordinate_cenocc_model, actual_cenocc_model.__class__)
+                    try:
+                        assert set(subordinate_cenocc_model.param_dict) == set(actual_cenocc_model.param_dict)
+                    except AttributeError:
+                        raise HalotoolsError("The ``centrals`` occupation model "
+                            "must have a ``param_dict`` attribute\n")
+                except AttributeError:
+                    pass
+                except AssertionError:
+                    msg = ("The occupation component of gal_type = ``{0}`` galaxies \n"
+                        "has a ``central_occupation_model`` attribute with an inconsistent \n"
+                        "implementation with the {1} class controlling the "
+                        "occupation statistics of the ``centrals`` population.\n"
+                        "If you use the ``cenocc_model`` feature, you must build a \n"
+                        "composite model with a self-consistent population of centrals.\n".format(
+                            component_model.gal_type, component_model.__class__.__name__))
+                    raise HalotoolsError(msg)
 
     def populate_mock(self, halocat, **kwargs):
         """

--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -217,7 +217,9 @@ class HodModelFactory(ModelFactory):
 
         self.model_dictionary = collections.OrderedDict()
         for key in self._model_feature_calling_sequence:
-            #Why a copy?
+            #  Making a copy is not strictly necessary, but we do it here to emphasize
+            #  at the syntax-level that the model_dictionary and _input_model_dictionary
+            #  are fully independent, not pointers to the same locations in memory
             self.model_dictionary[key] = copy(self._input_model_dictionary[key])
 
         # Build up and bind several lists from the component models

--- a/halotools/empirical_models/factories/tests/test_hod_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_factory.py
@@ -48,10 +48,6 @@ def test_Zheng07_composite():
     satocc_restored = model.mean_occupation_satellites(prim_haloprop=testmass2)
     assert satocc_restored == satocc_orig
 
-    #######################################################
-    # fakesim = FakeSim()
-    # model.populate_mock(halocat = fakesim)
-
 
 def test_alt_Zheng07_composites():
 
@@ -61,12 +57,12 @@ def test_alt_Zheng07_composites():
     default_satocc_component = default_model_dictionary['satellites_occupation']
     default_cenocc_component = default_model_dictionary['centrals_occupation']
 
-    cenmod_satocc_compoent = Zheng07Sats(
-        threshold=default_satocc_component.threshold, cenocc_model=default_cenocc_component,
+    cenmod_satocc_component = Zheng07Sats(
+        threshold=default_satocc_component.threshold, modulate_with_cenocc=True,
         gal_type_centrals='centrals')
 
     cenmod_model_dictionary = copy(default_model_dictionary)
-    cenmod_model_dictionary['satellites_occupation'] = cenmod_satocc_compoent
+    cenmod_model_dictionary['satellites_occupation'] = cenmod_satocc_component
     cenmod_model_dictionary['centrals_occupation'] = default_cenocc_component
     cenmod_model = factories.HodModelFactory(**cenmod_model_dictionary)
 
@@ -88,10 +84,6 @@ def test_alt_Zheng07_composites():
     default_model.param_dict['logMmin'] *= 1.1
     nsat4 = default_model.mean_occupation_satellites(prim_haloprop=2.e12)
     assert nsat3 == nsat4
-
-    fakesim = FakeSim()
-    # cenmod_model.populate_mock(halocat = fakesim)
-    # default_model.populate_mock(halocat = fakesim)
 
 
 def test_Leauthaud11_composite():

--- a/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
@@ -312,10 +312,10 @@ class TestZheng07Sats(TestCase):
         expected_result = 1.0
         np.testing.assert_allclose(mc_occ.mean(), expected_result, rtol=1e-2, atol=1.e-2)
 
-    def test_ncen_inheritance_behavior(self):
+    def test_ncen_inheritance_behavior1(self):
         satmodel_nocens = zheng07_components.Zheng07Sats()
         cenmodel = zheng07_components.Zheng07Cens()
-        satmodel_cens = zheng07_components.Zheng07Sats(cenocc_model=cenmodel)
+        satmodel_cens = zheng07_components.Zheng07Sats(modulate_with_cenocc=True)
 
         Npts = 100
         masses = np.logspace(10, 15, Npts)
@@ -328,6 +328,53 @@ class TestZheng07Sats(TestCase):
 
         mean_occ_cens = satmodel_cens.central_occupation_model.mean_occupation(prim_haloprop=masses)
         assert np.all(mean_occ_satmodel_cens == mean_occ_satmodel_nocens*mean_occ_cens)
+
+    def test_ncen_inheritance_behavior2(self):
+        """ Verify that the ``modulate_with_cenocc`` and ``cenocc_model``
+        keyword arguments behave as expected, including propagation of
+        param_dict values.
+        """
+        from .. import OccupationComponent
+
+        class MyCenModel(OccupationComponent):
+
+            def __init__(self, threshold):
+                OccupationComponent.__init__(self, gal_type='centrals',
+                        threshold=threshold, upper_occupation_bound=1.)
+                self.param_dict['new_cen_param'] = 0.5
+
+            def mean_occupation(self, **kwargs):
+                try:
+                    halo_table = kwargs['table']
+                    num_halos = len(halo_table)
+                except KeyError:
+                    mass_array = kwargs['prim_haloprop']
+                    num_halos = len(mass_array)
+
+                result = np.zeros(num_halos) + self.param_dict['new_cen_param']
+                return result
+
+        my_cen_model = MyCenModel(threshold=-20)
+        my_sat_model1 = zheng07_components.Zheng07Sats(
+            threshold=-20, modulate_with_cenocc=True, cenocc_model=my_cen_model)
+        my_sat_model2 = zheng07_components.Zheng07Sats(
+            threshold=-20, modulate_with_cenocc=True)
+        my_sat_model3 = zheng07_components.Zheng07Sats(
+            threshold=-20, modulate_with_cenocc=False, cenocc_model=my_cen_model)
+
+        mass_array = np.logspace(11, 15, 10)
+        result1a = my_sat_model1.mean_occupation(prim_haloprop=mass_array)
+        result2 = my_sat_model2.mean_occupation(prim_haloprop=mass_array)
+        result3 = my_sat_model3.mean_occupation(prim_haloprop=mass_array)
+
+        assert not np.allclose(result1a, result2, rtol=0.001)
+        assert not np.allclose(result1a, result3, rtol=0.001)
+        assert not np.allclose(result2, result3, rtol=0.001)
+
+        my_sat_model1.param_dict['new_cen_param'] = 1.
+        result1b = my_sat_model1.mean_occupation(prim_haloprop=mass_array)
+        assert not np.allclose(result1a, result1b, rtol=0.001)
+        assert np.allclose(result1b, result3, rtol=0.001)
 
     def test_alpha_scaling1_mean_occupation(self):
 
@@ -411,6 +458,15 @@ class TestZheng07Sats(TestCase):
         with pytest.raises(HalotoolsError) as err:
             _ = self.default_model.mean_occupation(x=4)
         substr = "You must pass either a ``table`` or ``prim_haloprop`` argument"
+        assert substr in err.value.args[0]
+
+    def test_occupation_component_requirement(self):
+        """ Verify that the optional ``cenocc_model`` input is correctly
+        enforced to be an instance of the OccupationComponent class.
+        """
+        with pytest.raises(HalotoolsError) as err:
+            __ = zheng07_components.Zheng07Sats(modulate_with_cenocc=True, cenocc_model=7)
+        substr = "``OccupationComponent`` or one of its sub-classes"
         assert substr in err.value.args[0]
 
     def test_get_published_parameters1(self):

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -56,7 +56,9 @@ class Zheng07Cens(OccupationComponent):
 
         See also
         ----------
-        TestZheng07Cens
+        :ref:`zheng07_composite_model`
+
+        :ref:`zheng07_using_cenocc_model_tutorial`
         """
         upper_occupation_bound = 1.0
 
@@ -222,8 +224,7 @@ class Zheng07Sats(OccupationComponent):
     def __init__(self,
             threshold=model_defaults.default_luminosity_threshold,
             prim_haloprop_key=model_defaults.prim_haloprop_key,
-            cenocc_model = None,
-            **kwargs):
+            modulate_with_cenocc=False, cenocc_model=None, **kwargs):
         """
         Parameters
         ----------
@@ -238,16 +239,27 @@ class Zheng07Sats(OccupationComponent):
             the occupation statistics of gal_type galaxies.
             Default value is specified in the `~halotools.empirical_models.model_defaults` module.
 
-        cenocc_model : bool, OccupationComponent 
-            If passed in, the first satellite moment will be multiplied by the
-            the first central moment. Default is None.
-            If ``cenocc_model`` is not None,
-            the mean occupation method of `Zheng07Sats` will
-            be multiplied by the the first moment of the new central occupation model. For example, 
-            if cenocc_model is an instance of Zheng07Cens the result will be 
-            as in Zheng et al. 2007, so that:
+        modulate_with_cenocc : bool, optional
+            If set to True, the `Zheng07Sats.mean_occupation` method will
+            be multiplied by the the first moment of the centrals:
 
             :math:`\\langle N_{\mathrm{sat}}\\rangle_{M}\\Rightarrow\\langle N_{\mathrm{sat}}\\rangle_{M}\\times\\langle N_{\mathrm{cen}}\\rangle_{M}`
+
+            The ``cenocc_model`` keyword argument works together with
+            the ``modulate_with_cenocc`` keyword argument to determine how
+            the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor is calculated.
+
+        cenocc_model : `OccupationComponent`, optional
+            If the ``cenocc_model`` keyword argument is set to its default value
+            of None, then the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor will be
+            calculated according to `Zheng07Cens.mean_occupation`.
+            However, if an instance of the `OccupationComponent` class is instead
+            passed in via the ``cenocc_model`` keyword,
+            then the first satellite moment will be multiplied by
+            the ``mean_occupation`` function of the ``cenocc_model``.
+            The ``modulate_with_cenocc`` keyword must be set to True in order
+            for the ``cenocc_model`` to be operative.
+            See :ref:`zheng07_using_cenocc_model_tutorial` for further details.
 
         Examples
         --------
@@ -273,22 +285,20 @@ class Zheng07Sats(OccupationComponent):
         to study the impact of this choice:
 
         >>> sat_model1 = Zheng07Sats(threshold=-18)
-        >>> cen_model_instance = Zheng07Cens(threshold = sat_model1.threshold)
-        >>> sat_model2 = Zheng07Sats(threshold = sat_model1.threshold, cenocc_model=cen_model_instance)
+        >>> sat_model2 = Zheng07Sats(threshold = sat_model1.threshold, modulate_with_cenocc=True)
 
         Now ``sat_model1`` and ``sat_model2`` are identical in every respect,
         excepting only the following difference:
 
         :math:`\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 2}} = \\langle N_{\mathrm{cen}}\\rangle\\times\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 1}}`
 
-
         See also
         ----------
-        TestZheng07Sats
+        :ref:`zheng07_composite_model`
+
+        :ref:`zheng07_using_cenocc_model_tutorial`
 
         """
-        #NOTE can put an assertion test here to ensure the user passed in a sensible cenocc_model.
-        #For now, trust the user *gulp*
         upper_occupation_bound = float("inf")
 
         # Call the super class constructor, which binds all the
@@ -301,13 +311,31 @@ class Zheng07Sats(OccupationComponent):
 
         self.param_dict = self.get_published_parameters(self.threshold)
 
-        self.central_occupation_model = cenocc_model 
+        if cenocc_model is None:
+            cenocc_model = Zheng07Cens(
+                prim_haloprop_key=prim_haloprop_key, threshold=threshold)
+        else:
+            if modulate_with_cenocc is False:
+                msg = ("You chose to input a ``cenocc_model``, but you set the \n"
+                    "``modulate_with_cenocc`` keyword to False, so your "
+                    "``cenocc_model`` will have no impact on the model's behavior.\n"
+                    "Be sure this is what you intend before proceeding.\n"
+                    "Refer to the Zheng et al. (2007) composite model tutorial for details.\n")
+                warnings.warn(msg)
 
-        if self.central_occupation_model is not None:
-            #Not sure if necessary, since they will presum
+        self.modulate_with_cenocc = modulate_with_cenocc
+        if self.modulate_with_cenocc:
+            try:
+                assert isinstance(cenocc_model, OccupationComponent)
+            except AssertionError:
+                msg = ("The input ``cenocc_model`` must be an instance of \n"
+                    "``OccupationComponent`` or one of its sub-classes.\n")
+                raise HalotoolsError(msg)
+
+            self.central_occupation_model = cenocc_model
+
             for key, value in self.central_occupation_model.param_dict.items():
                 self.param_dict[key] = value
-
 
         self.publications = ['arXiv:0308519', 'arXiv:0703457']
 
@@ -363,11 +391,10 @@ class Zheng07Sats(OccupationComponent):
         """
         #Turns out this is necessary
         #probably should have a check that parameters aren't being overwritten
-        if self.central_occupation_model is not None:
+        if self.modulate_with_cenocc:
             for key, value in self.param_dict.items():
                 if key in self.central_occupation_model.param_dict:
                     self.central_occupation_model.param_dict[key] = value
-
 
         # Retrieve the array storing the mass-like variable
         if 'table' in list(kwargs.keys()):
@@ -399,7 +426,7 @@ class Zheng07Sats(OccupationComponent):
 
         # If a central occupation model was passed to the constructor,
         # multiply mean_nsat by an overall factor of mean_ncen
-        if self.central_occupation_model is not None:
+        if self.modulate_with_cenocc:
             mean_ncen = self.central_occupation_model.mean_occupation(**kwargs)
             mean_nsat *= mean_ncen
 


### PR DESCRIPTION
This PR gives some further modifications along the lines originally suggested by @mclaughlin6464 in #567 and #568. Summary of changes:

1. (https://github.com/aphearin/halotools/commit/8d378e7176d146a31e291eff3379a157f0ac4305) The Zheng07Sats class now accepts two arguments: `moculate_with_cenocc=False`, and additionally `cenocc_model=None`. This implementation is completely compatible with previous default behavior, but provides the desired abstraction through the cenocc_model keyword. Some new unit-testing explicitly verifies the correct behavior. 

2. (https://github.com/aphearin/halotools/commit/0c163c982189271e99bccca2f7aa825eaabe7e0f) The `PrebuiltHodModelFactory(‘zheng07’)` raises an exception at an attempted use of the cenocc_model keyword. To build a composite model using the generality of the Zheng07Sats model that uses this keyword, it is necessary to use the HodModelFactory, as demonstrated in a new tutorial on advanced usage of the ‘zheng07’ model. Prohibiting the pre-built factory to use this feature is a sort of arbitrary judgement call over what should and should not be considered an entirely new model; hopefully it won't be too much of a hassle to use the real factory directly, but this could be up for discussion. Any strong opinion, @mclaughlin6464?